### PR TITLE
fix build on arm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ impl<R> Decoder<R> where R: Read + Seek {
         let buffer_len = buffer.len() * 2;
 
         match unsafe {
-            vorbisfile_sys::ov_read(&mut self.data.vorbis, buffer.as_mut_ptr() as *mut i8,
+            vorbisfile_sys::ov_read(&mut self.data.vorbis, buffer.as_mut_ptr() as *mut libc::c_char,
                 buffer_len as libc::c_int, 0, 2, 1, &mut self.data.current_logical_bitstream)
         } {
             0 => {


### PR DESCRIPTION
[ov_read has a `libc::c_char` as second paramter](https://github.com/tomaka/vorbisfile-sys/blob/8695a18201cdce7c8315bdc2a65e6c927c5408d4/src/lib.rs#L107), but you were casting to i8. This was working [on x86, where c_char is aliased to i8](https://github.com/rust-lang-nursery/libc/blob/ff38c3a1210e9f5a7e4072006d670fb575be15cd/src/unix/notbsd/linux/other/b32/x86.rs), but not on arm, because [on arm, c_char is aliased to u8](https://github.com/rust-lang-nursery/libc/blob/ff38c3a1210e9f5a7e4072006d670fb575be15cd/src/unix/notbsd/linux/other/b32/arm.rs). This commit changes the cast to match the type in the function signature.