### PR TITLE
Fix typo in VorbisQuality enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ pub enum VorbisQuality {
     Quality,
     Midium,
     Performance,
-    HighPerforamnce,
+    HighPerformance,
     VeryHighPerformance,
 }
 
@@ -306,7 +306,7 @@ impl Encoder {
             VorbisQuality::Quality => {0.6f32},
             VorbisQuality::Midium => {0.4f32},
             VorbisQuality::Performance => {0.3f32},
-            VorbisQuality::HighPerforamnce => {0.1f32},
+            VorbisQuality::HighPerformance => {0.1f32},
             VorbisQuality::VeryHighPerformance => {-0.1f32},
         };
         Ok(Encoder {


### PR DESCRIPTION
First things first, thank you for your work! I'm using rodio and vorbis in a side project, it's a pleasure to work with both those libraries.

This MR intends to fix a small typo in the VorbisQuality enum. I'm not entirely sure of "Midium" (should it be "Medium"?) as english is not my mother tongue.

This change may break the code of people using this library though, so feel free to close this MR if you don't want to bother bumping the major version just for a typo fix.