### PR TITLE
Update to Rust 2018 and make encoding an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ vorbis-sys = "0.1.0"
 vorbisfile-sys = "0.0.8"
 
 [dependencies.vorbis-encoder]
-version = "0.1"
+# Version with recent vorbis-sys is not on crates.io
+git = "https://github.com/Hossein-Noroozpour/vorbis-encoder-rs"
 optional = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,20 @@ license = "Apache-2.0"
 [dependencies]
 libc = "0.2"
 ogg-sys = "0.0.9"
-rand = "0.3"
-vorbis-sys = "0.0.8"
-vorbis-encoder = "0.1"
+vorbis-sys = "0.1.0"
 vorbisfile-sys = "0.0.8"
+
+[dependencies.vorbis-encoder]
+version = "0.1"
+optional = true
+
+[dev-dependencies]
+rand = "0.7"
+
+[features]
+default = ["encoder"]
+encoder = ["vorbis-encoder"]
+
+[[example]]
+name = "decode-encode"
+required-features = ["encoder"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "High-level bindings for the official libvorbis library."
 repository = "https://github.com/tomaka/vorbis-rs"
 license = "Apache-2.0"
+edition = "2018"
 
 [dependencies]
 libc = "0.2"

--- a/examples/decode-encode.rs
+++ b/examples/decode-encode.rs
@@ -56,7 +56,7 @@ fn main() {
     println!("bitrate_nominal: {:?}", bitrate_nominal);
     println!("bitrate_lower: {:?}", bitrate_lower);
     println!("bitrate_window: {:?}", bitrate_window);
-    let mut encoder = vorbis::Encoder::new(channels as u8, rate, vorbis::VorbisQuality::Midium).expect("Error in creating encoder");
+    let mut encoder = vorbis::Encoder::new(channels as u8, rate, vorbis::VorbisQuality::Medium).expect("Error in creating encoder");
     out_file.write(encoder.encode(&data).expect("Error in encoding.").as_slice()).expect("Error in writing");
     out_file.write(encoder.flush().expect("Error in flushing.").as_slice()).expect("Error in writing");
 }

--- a/examples/decode-encode.rs
+++ b/examples/decode-encode.rs
@@ -1,4 +1,5 @@
 extern crate vorbis;
+extern crate rand;
 
 use std::io::Write;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,9 +285,9 @@ pub enum VorbisQuality {
     VeryHighQuality,
     HighQuality,
     Quality,
-    Midium,
+    Medium,
     Performance,
-    HighPerforamnce,
+    HighPerformance,
     VeryHighPerformance,
 }
 
@@ -300,13 +300,13 @@ pub struct Encoder {
 impl Encoder {
     pub fn new(channels: u8, rate: u64, quality: VorbisQuality) -> Result<Self, VorbisError> {
         let quality = match quality {
-            VorbisQuality::VeryHighQuality => {1.0f32},
-            VorbisQuality::HighQuality => {0.8f32},
-            VorbisQuality::Quality => {0.6f32},
-            VorbisQuality::Midium => {0.4f32},
-            VorbisQuality::Performance => {0.3f32},
-            VorbisQuality::HighPerforamnce => {0.1f32},
-            VorbisQuality::VeryHighPerformance => {-0.1f32},
+            VorbisQuality::VeryHighQuality => 1.0f32,
+            VorbisQuality::HighQuality => 0.8f32,
+            VorbisQuality::Quality => 0.6f32,
+            VorbisQuality::Medium => 0.4f32,
+            VorbisQuality::Performance => 0.3f32,
+            VorbisQuality::HighPerformance => 0.1f32,
+            VorbisQuality::VeryHighPerformance => -0.1f32,
         };
         Ok(Encoder {
             e: match vorbis_encoder::Encoder::new(channels as u32, rate, quality) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 extern crate ogg_sys;
 extern crate vorbis_sys;
 extern crate vorbisfile_sys;
+#[cfg(feature = "encoder")]
 extern crate vorbis_encoder;
 extern crate libc;
-extern crate rand;
 
 use std::io::{self, Read, Seek};
 
@@ -283,6 +283,7 @@ fn check_errors(code: libc::c_int) -> Result<(), VorbisError> {
     }
 }
 
+#[cfg(feature = "encoder")]
 #[derive(Debug)]
 pub enum VorbisQuality {
     VeryHighQuality,
@@ -294,10 +295,12 @@ pub enum VorbisQuality {
     VeryHighPerformance,
 }
 
+#[cfg(feature = "encoder")]
 pub struct Encoder {
     e: vorbis_encoder::Encoder,
 }
 
+#[cfg(feature = "encoder")]
 impl Encoder {
     pub fn new(channels: u8, rate: u64, quality: VorbisQuality) -> Result<Self, VorbisError> {
         let quality = match quality {


### PR DESCRIPTION
Note: this PR supersedes #17 and #13

This PR:
- Creates an optional (enabled by default) `encoder` feature
- Updates the crate to Rust 2018
- Removes `rand` from `dependencies` and into `dev-dependencies`
- Fixes two typos made within the encoding section (including one #13 failed to correct)
- Updates all crates to most recent versions, `vorbis-encoder` is updated to Git master as crates.io version has outdated `vorbis-sys`

If needed, I can also apply `cargo fmt` before merging this PR.

This closes #16 