### PR TITLE
Fix panic in #19: "UB with std::mem::zeroed" and update crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,11 @@ license = "Apache-2.0"
 [dependencies]
 libc = "0.2"
 ogg-sys = "0.0.9"
-rand = "0.3"
-vorbis-sys = "0.0.8"
-vorbis-encoder = "0.1"
+rand = "0.8"
+vorbis-sys = "0.1"
 vorbisfile-sys = "0.0.8"
+
+vorbis-encoder = { version = "0.1", optional = true }
+
+[features]
+with-encoder = ["vorbis-encoder"]

--- a/examples/decode-encode.rs
+++ b/examples/decode-encode.rs
@@ -38,13 +38,13 @@ fn main() {
                 let mut index = 0;
                 for sample in packet.data {
                     file_data[index] = (sample as u32 & 255) as u8;
-                    index+=1;
+                    index += 1;
                     file_data[index] = ((sample as u32 >> 8) & 255) as u8;
-                    index+=1;
+                    index += 1;
                     data.push(sample);
                 }
                 pcm_file.write(&file_data[..]).unwrap();
-            },
+            }
             _ => {}
         }
     }
@@ -55,7 +55,17 @@ fn main() {
     println!("bitrate_nominal: {:?}", bitrate_nominal);
     println!("bitrate_lower: {:?}", bitrate_lower);
     println!("bitrate_window: {:?}", bitrate_window);
-    let mut encoder = vorbis::Encoder::new(channels as u8, rate, vorbis::VorbisQuality::Midium).expect("Error in creating encoder");
-    out_file.write(encoder.encode(&data).expect("Error in encoding.").as_slice()).expect("Error in writing");
-    out_file.write(encoder.flush().expect("Error in flushing.").as_slice()).expect("Error in writing");
+    let mut encoder = vorbis::Encoder::new(channels as u8, rate, vorbis::VorbisQuality::Midium)
+        .expect("Error in creating encoder");
+    out_file
+        .write(
+            encoder
+                .encode(&data)
+                .expect("Error in encoding.")
+                .as_slice(),
+        )
+        .expect("Error in writing");
+    out_file
+        .write(encoder.flush().expect("Error in flushing.").as_slice())
+        .expect("Error in writing");
 }


### PR DESCRIPTION
Original fix by: librespot-org/librespot-tremor#2

Move encoder to optional `with-encoder` feature. This is necessary because `vorbis-encoder` currently is in dependency hell. Ref: tomaka/vorbis-rs#16 with an even better fix in tomaka/vorbis-rs#18.